### PR TITLE
userName: fix format (example)

### DIFF
--- a/config.example.js
+++ b/config.example.js
@@ -1,5 +1,5 @@
 module.exports = {
-    userName: 'you@your.homeserver.tld',
+    userName: '@you:your.homeserver.tld',
     accessToken: 'go in your settings in riot, scroll to "Advanced", click to show "Access Token" and paste that here',
     historyLimit: 200
 };


### PR DESCRIPTION
the example format is incorrect

the split is `:` (hence, the `baseurl` is `undefined`) and you cannot connect to matrix server

```
{ error: 
   { Error: getaddrinfo ENOTFOUND undefined undefined:443
       at errnoException (dns.js:28:10)
       at GetAddrInfoReqWrap.onlookup [as oncomplete] (dns.js:76:26)
     code: 'ENOTFOUND',
     errno: 'ENOTFOUND',
     syscall: 'getaddrinfo',
     hostname: 'undefined',
     host: 'undefined',
     port: 443 } }
```

after that `matrix-js-sdk` suggests nicks starting with `@`

```
{ error: 
   { [M_UNKNOWN: Expected UserID string to start with '@']
     errcode: 'M_UNKNOWN',
     name: 'M_UNKNOWN',
     message: 'Expected UserID string to start with \'@\'',
     data: 
      { errcode: 'M_UNKNOWN',
        error: 'Expected UserID string to start with \'@\'' },
     httpStatus: 400 } }
```